### PR TITLE
Fix initialization from labels

### DIFF
--- a/spacy_experimental/edit_tree_lemmatizer/edit_tree_lemmatizer.py
+++ b/spacy_experimental/edit_tree_lemmatizer/edit_tree_lemmatizer.py
@@ -245,7 +245,10 @@ class EditTreeLemmatizer(TrainablePipe):
                     gold_label = self._pair2label(token.text, token.lemma_)
 
                 gold_labels.append(
-                    [1.0 if label == gold_label else 0.0 for label in self.cfg["labels"]]
+                    [
+                        1.0 if label == gold_label else 0.0
+                        for label in self.cfg["labels"]
+                    ]
                 )
 
             label_sample.append(self.model.ops.asarray(gold_labels, dtype="float32"))
@@ -324,6 +327,9 @@ class EditTreeLemmatizer(TrainablePipe):
                 subst_node["subst"] = self.vocab.strings[subst_node["subst"]]
 
         self.trees.from_json(trees)
+
+        for label, tree in enumerate(self.labels):
+            self.tree2label[tree] = label
 
     def _labels_from_data(self, get_examples: Callable[[], Iterable[Example]]):
         # Count corpus tree frequencies in ad-hoc storage to avoid cluttering

--- a/spacy_experimental/edit_tree_lemmatizer/tests/test_edit_tree_lemmatizer_pipe.py
+++ b/spacy_experimental/edit_tree_lemmatizer/tests/test_edit_tree_lemmatizer_pipe.py
@@ -42,6 +42,24 @@ def test_initialize_examples():
         nlp.initialize(get_examples=train_examples)
 
 
+def test_initialize_from_labels():
+    nlp = Language()
+    lemmatizer = nlp.add_pipe("experimental_edit_tree_lemmatizer")
+    lemmatizer.min_tree_freq = 1
+    train_examples = []
+    for t in TRAIN_DATA:
+        train_examples.append(Example.from_dict(nlp.make_doc(t[0]), t[1]))
+    nlp.initialize(get_examples=lambda: train_examples)
+
+    nlp2 = Language()
+    lemmatizer2 = nlp2.add_pipe("experimental_edit_tree_lemmatizer")
+    lemmatizer2.initialize(
+        get_examples=lambda: train_examples,
+        labels=lemmatizer.label_data,
+    )
+    assert lemmatizer2.tree2label == {1: 0, 3: 1, 4: 2, 6: 3}
+
+
 def test_no_data():
     # Test that the lemmatizer provides a nice error when there's no tagging data / labels
     TEXTCAT_DATA = [


### PR DESCRIPTION
When initializing the edit tree lemmatizer from labels, the tree2label mapping
was not generated. Also add a test that verifies that the mapping is set up.
