### PR TITLE
`Coref`: Optimize `create_gold_scores`

### DIFF
--- a/spacy_experimental/coref/coref_component.py
+++ b/spacy_experimental/coref/coref_component.py
@@ -305,16 +305,13 @@ class CoreferenceResolver(TrainablePipe):
 
         span_idxs = create_head_span_idxs(ops, len(example.predicted))
         gscores = create_gold_scores(span_idxs, clusters)
-        # Note on type here. This is bools but asarray2f wants ints.
+        # Ensure that the returned array has the same backend as the model.
         gscores = ops.asarray2f(gscores)  # type: ignore
         top_gscores = xp.take_along_axis(gscores, mention_idx, axis=1)
         # now add the placeholder
         gold_placeholder = ~top_gscores.any(axis=1).T
         gold_placeholder = xp.expand_dims(gold_placeholder, 1)
         top_gscores = xp.concatenate((gold_placeholder, top_gscores), 1)
-
-        # boolean to float
-        top_gscores = ops.asarray2f(top_gscores)
 
         with warnings.catch_warnings():
             # This builds a mask by building a matrix of 0/1 values and taking


### PR DESCRIPTION
Copy the entire mentions array to the CPU, create tuple keys on-demand, pre-allocate output matrix as `Float2d`. Also remove unnecessary casts in `CoreferenceResolver.update`.

## Before
![Screenshot_20220824_153937](https://user-images.githubusercontent.com/214450/186433470-0443645b-f72e-483d-842b-2c524aae7560.png)


## After
![Screenshot_20220824_154002](https://user-images.githubusercontent.com/214450/186433491-9a518e02-611e-4da8-ba55-cfe343fede7d.png)
