### PR TITLE
`Coref`: Optimize `SpanResolver.set_annotations`

### DIFF
--- a/spacy_experimental/coref/span_resolver_component.py
+++ b/spacy_experimental/coref/span_resolver_component.py
@@ -176,7 +176,7 @@ class SpanResolver(TrainablePipe):
         """
         for doc, clusters in zip(docs, clusters_by_doc):
             for ii, cluster in enumerate(clusters, 1):
-                spans = [doc[mm[0] : mm[1]] for mm in cluster]
+                spans = [doc[int(mm[0]) : int(mm[1])] for mm in cluster]
                 doc.spans[f"{self.output_prefix}_{ii}"] = spans
 
     def update(


### PR DESCRIPTION
Coerce scalar tensors to native Python integers to avoid comparison overhead.

With the above change (and another optimization to `SpanGroups.copy`; [PR](https://github.com/explosion/spacy-experimental/pull/20)), we see a 90% reduction in execution time of the `set_annotation` pipeline phase.

## Before
![Screenshot_20220825_154448](https://user-images.githubusercontent.com/214450/186681752-b5819578-25c1-4e0c-8175-151e135045a4.png)

## After 
![Screenshot_20220825_154626](https://user-images.githubusercontent.com/214450/186681904-583b0b3c-3b9b-4d64-b1d2-afadc5123bbc.png)
