### PR TITLE
Add test step before PyTorch is installed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,10 @@ jobs:
 
   - script: |
       pip install -r requirements.txt
+      python -m pytest --pyargs spacy_experimental
+    displayName: 'Run tests without PyTorch'
+
+  - script: |
       pip install "torch==1.10.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
       python -m pytest --pyargs spacy_experimental
-    displayName: 'Run tests'
+    displayName: 'Run tests with PyTorch'


### PR DESCRIPTION
spacy-experimental is supposed to be safe to load without PyTorch, even if large parts of it aren't functional, but that wasn't checked in tests. This adds a check for that by simply running the tests before installing PyTorch and again afterwards.

Given the current state of master, which doesn't have #23, this should fail. 