### PR TITLE
Fix device issue with indices in coref

### DIFF
--- a/spacy_experimental/coref/pytorch_coref_model.py
+++ b/spacy_experimental/coref/pytorch_coref_model.py
@@ -265,7 +265,7 @@ class DistancePairwiseEncoder(nn.Module):
         self.shape = emb_size
 
     def forward(self, top_indices: torch.Tensor) -> torch.Tensor:
-        word_ids = torch.arange(0, top_indices.size(0))
+        word_ids = torch.arange(0, top_indices.size(0), device=top_indices.device)
         distance = (word_ids.unsqueeze(1) - word_ids[top_indices]).clamp_min_(min=1)
         log_distance = distance.to(torch.float).log2().floor_()
         log_distance = log_distance.clamp_max_(max=6).to(torch.long)


### PR DESCRIPTION
It looks like Torch 1.13.0 has some changes in the way devices are handled and can result in subtle errors in code that worked previously. This explicitly specifies a device in one place, and may resolve https://github.com/explosion/spaCy/issues/11734. For another example of this issue, see https://github.com/pytorch/pytorch/issues/85450. 

The core problem is that a CPU tensor is being indexed using a non-CPU tensor. 

Leaving as a draft in case this doesn't resolve this issue, which might happen if we're doing the same thing somewhere else.