### PR TITLE
arc_predicter: replace lazy splitting by iterative implementation

### DIFF
--- a/spacy_experimental/biaffine_parser/arc_predicter.pyx
+++ b/spacy_experimental/biaffine_parser/arc_predicter.pyx
@@ -333,7 +333,7 @@ def split_lazily(docs: List[Doc], *, ops: Ops, max_tokens: int, senter_name: str
     return ops.asarray1i(lens)
 
 
-def _split_lazily_doc(ops: Ops, scores: Floats2d,  max_tokens: int, lens: List[int]):
+def _split_lazily_doc(ops: Ops, scores: Floats2d, max_tokens: int, lens: List[int]):
     q = deque([scores])
     while q:
         scores = q.popleft()

--- a/spacy_experimental/biaffine_parser/arc_predicter.pyx
+++ b/spacy_experimental/biaffine_parser/arc_predicter.pyx
@@ -334,14 +334,16 @@ def split_lazily(docs: List[Doc], *, ops: Ops, max_tokens: int, senter_name: str
 
 
 def _split_lazily_doc(ops: Ops, scores: Floats2d, max_tokens: int, lens: List[int]):
-    q = deque([scores])
-    while q:
-        scores = q.popleft()
+    stack = deque([scores])
+    while stack:
+        scores = stack.pop()
         if len(scores) <= max_tokens:
             lens.append(len(scores))
         else:
             # Find the best splitting point. Exclude the first token, because it
             # wouldn't split the current partition (leading to infinite recursion).
             start = ops.xp.argmax(scores[1:]) + 1
-            q.appendleft(scores[start:])
-            q.appendleft(scores[:start])
+            # Initial split goes last, so that it is taken off the stack first
+            # in the next iteration.
+            stack.append(scores[start:])
+            stack.append(scores[:start])

--- a/spacy_experimental/biaffine_parser/arc_predicter.pyx
+++ b/spacy_experimental/biaffine_parser/arc_predicter.pyx
@@ -1,6 +1,7 @@
 # cython: infer_types=True, profile=True, binding=True
 
 from itertools import islice
+from collections import deque
 import numpy as np
 from typing import Callable, Dict, Iterable, List, Optional
 import spacy
@@ -305,6 +306,7 @@ class ArcPredicter(TrainablePipe):
 
         self.model.initialize()
 
+
 def sents2lens(docs: List[Doc], *, ops: Ops) -> Ints1d:
     """Get the lengths of sentences."""
     lens = []
@@ -323,21 +325,23 @@ def split_lazily(docs: List[Doc], *, ops: Ops, max_tokens: int, senter_name: str
             raise ValueError(f"Lazy splitting requires senter pipe `{senter_name}` to have ",
                               "`save_activations` enabled.\nDuring training, `senter` must be "
                               "in the list of annotating components.")
-        scores = activations['probabilities']
-        split_recursive(scores[:,1], ops, max_tokens, lens)
+        scores = activations['probabilities'][:, 1]
+        _split_lazily_doc(ops, scores, max_tokens, lens)
 
     assert sum(lens) == sum([len(doc) for doc in docs])
 
     return ops.asarray1i(lens)
 
 
-def split_recursive(scores, ops, max_tokens, lengths):
-    if len(scores) < max_tokens:
-        lengths.append(len(scores))
-    else:
-        # Find the best splitting point. Exclude the first token, because it
-        # wouldn't split the current partition (leading to infinite recursion).
-        start = ops.xp.argmax(scores[1:]) + 1
-
-        split_recursive(scores[:start], ops, max_tokens, lengths)
-        split_recursive(scores[start:], ops, max_tokens, lengths)
+def _split_lazily_doc(ops: Ops, scores: Floats2d,  max_tokens: int, lens: List[int]):
+    q = deque([scores])
+    while q:
+        scores = q.popleft()
+        if len(scores) <= max_tokens:
+            lens.append(len(scores))
+        else:
+            # Find the best splitting point. Exclude the first token, because it
+            # wouldn't split the current partition (leading to infinite recursion).
+            start = ops.xp.argmax(scores[1:]) + 1
+            q.appendleft(scores[start:])
+            q.appendleft(scores[:start])

--- a/spacy_experimental/biaffine_parser/tests/test_arc_predicter.py
+++ b/spacy_experimental/biaffine_parser/tests/test_arc_predicter.py
@@ -3,6 +3,9 @@ from spacy import util
 from spacy.lang.en import English
 from spacy.language import Language
 from spacy.training import Example
+from thinc.api import NumpyOps
+
+from spacy_experimental.biaffine_parser.arc_predicter import _split_lazily_doc
 
 
 pytest.importorskip("torch")
@@ -159,3 +162,23 @@ def test_senter_check():
 
     senter.save_activations = True
     list(nlp.pipe([nlp.make_doc("Test")]))
+
+
+def test_split_lazily():
+    ops = NumpyOps()
+
+    lens = []
+    _split_lazily_doc(ops, ops.xp.arange(5.0), 2, lens)
+    assert lens == [2, 1, 1, 1]
+
+    lens = []
+    _split_lazily_doc(ops, ops.xp.arange(5.0, 0.0, -1.0), 2, lens)
+    assert lens == [1, 1, 1, 2]
+
+    lens = []
+    _split_lazily_doc(ops, ops.asarray1f([0.0, 1.0, 0.0, 1.0, 0.0]), 2, lens)
+    assert lens == [1, 2, 2]
+
+    lens = []
+    _split_lazily_doc(ops, ops.asarray1f([1.0, 0.0, 1.0, 0.0, 1.0]), 2, lens)
+    assert lens == [2, 2, 1]


### PR DESCRIPTION
The `split_lazily` function was defined recursively. This can cause the Python interpreter reach the maximum recursion depth. This wouldn't happen under normal circumstances when the recursion depth is O(log2(N)). However, the softmax layer of senter is zero-initialized, giving each token the same split probability. This results in the degenerate case where we split recursively after each token.

This change avoids such corner cases by replacing the implementation by an iterative solution.