### PR TITLE
Make the memory use of the pairwise linear model constant

### DIFF
--- a/spacy_experimental/biaffine_parser/_util.py
+++ b/spacy_experimental/biaffine_parser/_util.py
@@ -1,0 +1,12 @@
+from thinc.api import get_array_module
+from thinc.types import Ints1d
+
+
+def lengths2offsets(lens: Ints1d) -> Ints1d:
+    """Convert an array of lengths to an array of offsets. For instance,
+    the array [6, 3, 5] is converted into the offsets [0, 6, 9]."""
+    xp = get_array_module(lens)
+    starts_ends = xp.empty(len(lens) + 1, dtype="i")
+    starts_ends[0] = 0
+    lens.cumsum(out=starts_ends[1:])
+    return starts_ends[:-1]

--- a/spacy_experimental/biaffine_parser/pairwise_bilinear.py
+++ b/spacy_experimental/biaffine_parser/pairwise_bilinear.py
@@ -1,11 +1,22 @@
-from typing import List, Optional, Tuple, Union, cast
-
+from typing import Callable, List, Optional, Tuple, TypeVar, Union
+from typing import cast
 from spacy import registry
 from spacy.tokens.doc import Doc
-from thinc.api import Model, chain, get_width, list2array, torch2xp
+from thinc.api import Model, chain, get_width, torch2xp
 from thinc.api import with_getitem, xp2torch
 from thinc.shims.pytorch_grad_scaler import PyTorchGradScaler
-from thinc.types import ArgsKwargs, Floats2d, Floats3d, Floats4d, Ints1d
+from thinc.types import (
+    ArgsKwargs,
+    Floats2d,
+    Floats3d,
+    Floats4d,
+    Ints1d,
+)
+
+
+from .with_minibatch_by_padded_size import with_minibatch_by_padded_size
+from .with_pad_seq_unpad_matrix import with_pad_seq_unpad_matrix
+from .with_splits import with_splits
 
 # Ensure that the spacy-experimental package can register entry points without
 # Torch installed.
@@ -18,15 +29,44 @@ except ImportError:
     PyTorchPairwiseBilinearModel = None
 
 
+# Model notes
+#
+# The Thinc part of the pairwire bilinear model used to be fairly simple: we
+# would collect the splits from all documents and then pad them. However, this
+# would run the parser out of GPU memory on very large docs. So instead, we do
+# the following:
+#
+# - Get all splits and flatten to a list of split representations.
+#   (with_splits)
+# - Batch the splits by their padded sizes. This ensures that memory
+#   use is constant when splits have a maximum size. This also permits
+#   some buffering, so that we get more equisized batches.
+#   (with_minibatch_by_padded_size)
+# - The splits in the batches are padded and passed to the Torch model.
+#   Since the outputs of the Torch model are matrices, we unpad taking
+#   this into account. (with_pad_seq_unpad_matrix)
+#
+# In contrast to most with_* layers, with_splits is not symmetric. It
+# takes at its input representations for each document (List[Floats2d]),
+# however it outputs pairwise score matrices per split. The reason is that
+# since the dimensions of the score matrices differ per split, we cannot
+# concatenate them at a document level.
+
+
+InT = TypeVar("InT")
+OutT = TypeVar("OutT")
+
+
 def build_pairwise_bilinear(
     tok2vec: Model[List[Doc], List[Floats2d]],
     nO=None,
     *,
     dropout: float = 0.1,
     hidden_width: int = 128,
+    max_items: int = 4096,
     mixed_precision: bool = False,
     grad_scaler: Optional[PyTorchGradScaler] = None
-) -> Model[Tuple[List[Doc], Ints1d], Floats2d]:
+) -> Model[Tuple[List[Doc], List[Ints1d]], List[Floats2d]]:
     if PyTorchPairwiseBilinearModel is None:
         raise ImportError(
             "PairwiseBiLinear layer requires PyTorch: pip install thinc[torch]"
@@ -36,7 +76,7 @@ def build_pairwise_bilinear(
     if tok2vec.has_dim("nO") is True:
         nI = tok2vec.get_dim("nO")
 
-    pairwise_bilinear: Model[Tuple[Floats2d, Ints1d], Floats2d] = Model(
+    pairwise_bilinear: Model[Tuple[Floats3d, Ints1d], Floats3d] = Model(
         "pairwise_bilinear",
         forward=pairwise_bilinear_forward,
         init=pairwise_bilinear_init,
@@ -51,14 +91,16 @@ def build_pairwise_bilinear(
         },
     )
 
-    model: Model[Tuple[List[Doc], Ints1d], Floats2d] = chain(
+    model: Model[Tuple[List[Doc], List[Ints1d]], List[Floats2d]] = chain(
         cast(
-            Model[Tuple[List[Doc], Ints1d], Tuple[Floats2d, Ints1d]],
-            with_getitem(
-                0, chain(tok2vec, cast(Model[List[Floats2d], Floats2d], list2array()))
-            ),
+            Model[Tuple[List[Doc], List[Ints1d]], Tuple[List[Floats2d], List[Ints1d]]],
+            with_getitem(0, tok2vec),
         ),
-        pairwise_bilinear,
+        with_splits(
+            with_minibatch_by_padded_size(
+                with_pad_seq_unpad_matrix(pairwise_bilinear), size=max_items
+            )
+        ),
     )
     model.set_ref("pairwise_bilinear", pairwise_bilinear)
 
@@ -106,42 +148,35 @@ def pairwise_bilinear_forward(model: Model, X, is_train: bool):
 
 def convert_inputs(
     model: Model, X_lenghts: Tuple[Floats2d, Ints1d], is_train: bool = False
-):
-    flatten = model.ops.flatten
-    unflatten = model.ops.unflatten
-    pad = model.ops.pad
-    unpad = model.ops.unpad
-
+) -> Tuple[ArgsKwargs, Callable[[ArgsKwargs], Floats3d]]:
     X, L = X_lenghts
 
-    Xt = xp2torch(pad(unflatten(X, L)), requires_grad=is_train)
+    Xt = xp2torch(X, requires_grad=is_train)
     Lt = xp2torch(L)
 
-    def convert_from_torch_backward(d_inputs: ArgsKwargs) -> Tuple[Floats2d, Ints1d]:
+    def convert_from_torch_backward(d_inputs: ArgsKwargs) -> Floats3d:
         dX = cast(Floats3d, torch2xp(d_inputs.args[0]))
-        return cast(Floats2d, flatten(unpad(dX, list(L)))), L
+        return dX
 
     output = ArgsKwargs(args=(Xt, Lt), kwargs={})
 
     return output, convert_from_torch_backward
 
 
-def convert_outputs(model, inputs_outputs, is_train):
-    flatten = model.ops.flatten
-    unflatten = model.ops.unflatten
-    pad = model.ops.pad
-    unpad = model.ops.unpad
-
+def convert_outputs(
+    model, inputs_outputs, is_train: bool
+) -> Tuple[
+    Union[Floats3d, Floats4d], Callable[[Union[Floats3d, Floats4d]], ArgsKwargs]
+]:
     (_, lengths), Y_t = inputs_outputs
 
     def convert_for_torch_backward(dY: Union[Floats3d, Floats4d]) -> ArgsKwargs:
-        dY_t = xp2torch(pad(unflatten(dY, lengths)))
+        dY_t = xp2torch(dY)
         return ArgsKwargs(
             args=([Y_t],),
             kwargs={"grad_tensors": [dY_t]},
         )
 
-    Y = cast(Floats4d, torch2xp(Y_t))
-    Y = flatten(unpad(Y, lengths))
+    Y = cast(Union[Floats3d, Floats4d], torch2xp(Y_t))
 
     return Y, convert_for_torch_backward

--- a/spacy_experimental/biaffine_parser/tests/test_arc_predicter.py
+++ b/spacy_experimental/biaffine_parser/tests/test_arc_predicter.py
@@ -13,11 +13,23 @@ pytest.importorskip("torch")
 
 TRAIN_DATA = [
     (
-        "She likes green eggs",
+        "She likes green eggs. She is eating them today.",
         {
-            "heads": [1, 1, 3, 1],
-            "deps": ["nsubj", "ROOT", "amod", "dobj"],
-            "sent_starts": [1, 0, 0, 0],
+            "heads": [1, 1, 3, 1, 1, 7, 7, 7, 7, 7, 7],
+            "deps": [
+                "nsubj",
+                "ROOT",
+                "amod",
+                "dobj",
+                "punct",
+                "nsubj",
+                "aux",
+                "ROOT",
+                "dobj",
+                "npadvmod",
+                "punct",
+            ],
+            "sent_starts": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0],
         },
     ),
     (
@@ -167,18 +179,14 @@ def test_senter_check():
 def test_split_lazily():
     ops = NumpyOps()
 
-    lens = []
-    _split_lazily_doc(ops, ops.xp.arange(5.0), 2, lens)
+    lens = _split_lazily_doc(ops, ops.xp.arange(5.0), 2)
     assert lens == [2, 1, 1, 1]
 
-    lens = []
-    _split_lazily_doc(ops, ops.xp.arange(5.0, 0.0, -1.0), 2, lens)
+    lens = _split_lazily_doc(ops, ops.xp.arange(5.0, 0.0, -1.0), 2)
     assert lens == [1, 1, 1, 2]
 
-    lens = []
-    _split_lazily_doc(ops, ops.asarray1f([0.0, 1.0, 0.0, 1.0, 0.0]), 2, lens)
+    lens = _split_lazily_doc(ops, ops.asarray1f([0.0, 1.0, 0.0, 1.0, 0.0]), 2)
     assert lens == [1, 2, 2]
 
-    lens = []
-    _split_lazily_doc(ops, ops.asarray1f([1.0, 0.0, 1.0, 0.0, 1.0]), 2, lens)
+    lens = _split_lazily_doc(ops, ops.asarray1f([1.0, 0.0, 1.0, 0.0, 1.0]), 2)
     assert lens == [2, 2, 1]

--- a/spacy_experimental/biaffine_parser/tests/test_with_minibatch_by_padded_size.py
+++ b/spacy_experimental/biaffine_parser/tests/test_with_minibatch_by_padded_size.py
@@ -1,0 +1,37 @@
+from thinc.api import Model, noop
+from spacy_experimental.biaffine_parser.with_minibatch_by_padded_size import (
+    with_minibatch_by_padded_size,
+)
+
+
+def _memoize():
+    return Model("memoize", memoize_forward, attrs={"X": [], "dY": []})
+
+
+def memoize_forward(model: Model, X, is_train):
+    model.attrs["X"].append(X)
+
+    def backprop(dY):
+        model.attrs["dY"].append(dY)
+        return dY
+
+    return X, backprop
+
+
+def test_batching():
+    model = with_minibatch_by_padded_size(_memoize(), size=18)
+    X = ["peach", "banana", "apple", "pineapple"]
+    _, backprop = model(X, True)
+    backprop(["a", "b", "c", "d"])
+    assert model.layers[0].attrs["X"] == [["pineapple"], ["peach", "banana", "apple"]]
+    assert model.layers[0].attrs["dY"] == [["d"], ["a", "b", "c"]]
+
+
+def test_output():
+    # Check that outupts are in the same order as inputs.
+    model = with_minibatch_by_padded_size(noop(), size=18)
+    X = ["peach", "banana", "apple", "pineapple"]
+    Y, backprop = model(X, True)
+    assert Y == ["peach", "banana", "apple", "pineapple"]
+    dX = backprop(["a", "b", "c", "d"])
+    assert dX == ["a", "b", "c", "d"]

--- a/spacy_experimental/biaffine_parser/tests/test_with_pad_seq_unpad_matrix.py
+++ b/spacy_experimental/biaffine_parser/tests/test_with_pad_seq_unpad_matrix.py
@@ -1,0 +1,61 @@
+from typing import Callable, Tuple
+from thinc.api import Model
+from thinc.types import Floats3d, Ints1d
+
+from spacy_experimental.biaffine_parser.with_pad_seq_unpad_matrix import (
+    InnerInT,
+    InnerOutT,
+    with_pad_seq_unpad_matrix,
+)
+
+
+def _mock_model():
+    return Model("mock_model", _mock_model_forward)
+
+
+def _mock_model_forward(
+    model: Model[InnerInT, InnerOutT], X: InnerInT, is_train: bool
+) -> Tuple[InnerOutT, Callable[[InnerOutT], InnerInT]]:
+    Xf, lens = X
+
+    # Do something resembling our pairwise bilinear layer.
+    Y = Xf @ Xf.transpose(0, 2, 1)  # type: ignore
+
+    def backprop(dY: InnerOutT) -> InnerInT:
+        model.attrs["last_dY"] = dY
+        return Xf + 1.0, lens
+
+    return Y, backprop
+
+
+def test_with_pad_seq_unpad_matrix():
+    model = with_pad_seq_unpad_matrix(_mock_model())
+    X = [
+        model.ops.xp.arange(6, dtype="float32").reshape(3, 2),
+        model.ops.xp.arange(4, dtype="float32").reshape(2, 2),
+    ]
+    Y, backprop = model(
+        X,
+        True,
+    )
+
+    model.ops.xp.testing.assert_equal(
+        Y,
+        [
+            model.ops.asarray2f([[1, 3, 5], [3, 13, 23], [5, 23, 41]], dtype="float32"),
+            model.ops.asarray2f([[1, 3], [3, 13]]),
+        ],
+    )
+
+    dY = [
+        model.ops.xp.arange(9, dtype="float32").reshape(3, 3),
+        model.ops.xp.arange(4, dtype="float32").reshape(2, 2),
+    ]
+
+    dX = backprop(dY)
+
+    model.ops.xp.testing.assert_equal(dX, [X[0] + 1.0, X[1] + 1.0])
+    model.ops.xp.testing.assert_equal(
+        model.layers[0].attrs["last_dY"],
+        [dY[0], model.ops.asarray2f([[0, 1, 0], [2, 3, 0], [0, 0, 0]])],
+    )

--- a/spacy_experimental/biaffine_parser/tests/test_with_splits.py
+++ b/spacy_experimental/biaffine_parser/tests/test_with_splits.py
@@ -1,0 +1,44 @@
+from thinc.api import Model, noop
+from spacy_experimental.biaffine_parser.with_splits import with_splits
+
+
+def _memoize():
+    return Model("memoize", memoize_forward, attrs={"X": [], "dY": []})
+
+
+def memoize_forward(model: Model, X, is_train):
+    model.attrs["X"].append(X)
+
+    def backprop(dY):
+        model.attrs["dY"].append(dY)
+        return dY
+
+    return X, backprop
+
+
+def test_with_splits():
+    model = with_splits(_memoize())
+    doc1 = model.ops.xp.arange(9, dtype="float32").reshape(3, 3)
+    doc2 = model.ops.xp.arange(6, dtype="float32").reshape(2, 3)
+    _, backprop = model(
+        ([doc1, doc2], [model.ops.asarray1i([1, 2]), model.ops.asarray1i([2])]), True
+    )
+
+    check_output = [
+        model.ops.asarray2f([[0, 1, 2]]),
+        model.ops.asarray2f([[3, 4, 5], [6, 7, 8]]),
+        model.ops.asarray2f([[0, 1, 2], [3, 4, 5]]),
+    ]
+
+    X_inner = model.layers[0].attrs["X"]
+    model.ops.xp.testing.assert_equal(
+        X_inner,
+        [check_output],
+    )
+
+    backprop(check_output)
+    dY_inner = model.layers[0].attrs["dY"]
+    model.ops.xp.testing.assert_equal(
+        dY_inner,
+        [check_output],
+    )

--- a/spacy_experimental/biaffine_parser/with_minibatch_by_padded_size.py
+++ b/spacy_experimental/biaffine_parser/with_minibatch_by_padded_size.py
@@ -1,0 +1,84 @@
+from typing import Callable, Generic, List, Optional, Sized, Tuple, TypeVar, cast
+from dataclasses import dataclass
+from spacy.training.batchers import minibatch_by_padded_size
+from thinc.api import Model
+
+
+OutT = TypeVar("OutT")
+SizedInT = TypeVar("SizedInT", bound=Sized)
+
+
+@dataclass
+class ItemIndex(Generic[SizedInT]):
+    value: SizedInT
+    idx: int
+
+    def __len__(self):
+        return len(self.value)
+
+
+def with_minibatch_by_padded_size(
+    inner: Model[List[SizedInT], List[OutT]], size: int, buffer: int = 256
+) -> Model[List[SizedInT], List[OutT]]:
+    """Batch the inputs sorted by length and with a maximum number of
+    padded batch items."""
+    return Model(
+        "with_minibatch_by_padded_size",
+        with_minibatch_by_padded_size_forward,
+        init=with_minibatch_by_padded_size_init,
+        attrs={"buffer": buffer, "size": size},
+        layers=[inner],
+    )
+
+
+def with_minibatch_by_padded_size_init(
+    model: Model[List[SizedInT], List[OutT]], X: Optional[SizedInT] = None, Y=None
+) -> None:
+    # Pass X through as-is. Downstream models don't need the batching
+    # for proper initialization.
+    model.layers[0].initialize(X=X, Y=Y)
+
+
+def with_minibatch_by_padded_size_forward(
+    model: Model[List[SizedInT], List[OutT]],
+    X: List[SizedInT],
+    is_train: bool,
+) -> Tuple[List[OutT], Callable[[List[OutT]], List[SizedInT]]]:
+    inner: Model[List[SizedInT], List[OutT]] = model.layers[0]
+    buffer: int = model.attrs["buffer"]
+    size: int = model.attrs["size"]
+
+    batched = list(
+        minibatch_by_padded_size(
+            [ItemIndex(idx=idx, value=item) for idx, item in enumerate(X)],
+            size,
+            buffer=buffer,
+        )
+    )
+
+    backprops = []
+    Y: List[Optional[OutT]] = [None] * len(X)
+    for batch in batched:
+        X_batch = [split.value for split in batch]
+        Y_batch, backprop_batch = inner(X_batch, is_train)
+        backprops.append(backprop_batch)
+
+        # Place in outputs.
+        offsets_batch = [split.idx for split in batch]
+        for split_offset, Y_split in zip(offsets_batch, Y_batch):
+            Y[split_offset] = Y_split
+
+    assert not any(y is None for y in Y)
+
+    def backprop(dY: List[OutT]) -> List[SizedInT]:
+        dX: List[Optional[SizedInT]] = [None] * len(X)
+        for idx, batch in enumerate(batched):
+            dY_batch = [dY[split.idx] for split in batch]
+            for split, dX_split in zip(batch, backprops[idx](dY_batch)):
+                dX[split.idx] = dX_split
+
+        assert not any(dx is None for dx in dX)
+
+        return cast(List[SizedInT], dX)
+
+    return cast(List[OutT], Y), backprop

--- a/spacy_experimental/biaffine_parser/with_pad_seq_unpad_matrix.py
+++ b/spacy_experimental/biaffine_parser/with_pad_seq_unpad_matrix.py
@@ -1,0 +1,94 @@
+from typing import Callable, List, Optional, Tuple, cast
+from thinc.api import Model, Ops
+from thinc.types import Floats2d, Floats3d, Ints1d
+
+InT = List[Floats2d]
+OutT = List[Floats2d]
+InnerInT = Tuple[Floats3d, Ints1d]
+InnerOutT = Floats3d
+
+
+def with_pad_seq_unpad_matrix(inner: Model[InnerInT, InnerOutT]) -> Model[InT, OutT]:
+    """This layer is similar to with_padded, however it unpads
+    correctly for layers that take sequences and output matrices."""
+    return Model(
+        "with_pad_seq_unpad_bilinear",
+        with_pad_seq_unpad_matrix_forward,
+        init=with_pad_seq_unpad_matrix_init,
+        layers=[inner],
+    )
+
+
+def with_pad_seq_unpad_matrix_init(
+    model: Model[InT, OutT], X: Optional[InT] = None, Y=None
+):
+    inner = model.layers[0]
+    if X is not None:
+        lengths = [len(Xs) for Xs in X]
+        inner.initialize((model.ops.pad(X), model.ops.asarray1i(lengths)), Y)
+    else:
+        inner.initialize(X, Y)
+
+
+def with_pad_seq_unpad_matrix_forward(
+    model: Model[InT, OutT],
+    X: InT,
+    is_train: bool,
+) -> Tuple[OutT, Callable[[OutT], InT]]:
+    inner = model.layers[0]
+
+    lengths = [len(Xs) for Xs in X]
+
+    X_padded = model.ops.pad(X)
+    Y_padded, backprop_inner = inner((X_padded, model.ops.asarray1i(lengths)), is_train)
+    Y = unpad_matrix(Y_padded, lengths)
+
+    def backprop(dY: List[Floats2d]) -> List[Floats2d]:
+        dY_padded = pad_matrix(model.ops, dY)
+        dX_padded, _ = backprop_inner(dY_padded)
+        dX = model.ops.unpad(dX_padded, lengths)
+        return cast(List[Floats2d], dX)
+
+    return Y, backprop
+
+
+def pad_matrix(ops: Ops, seqs: List[Floats2d], round_to=1) -> Floats3d:
+    """Perform padding on a list of arrays so that they each have the same
+    length, by taking the maximum dimension across each axis. This only
+    works on non-empty sequences with the same `ndim` and `dtype`.
+
+    Different from Thinc, because it operates on a matrix with padding
+    in two dimensions.
+    """
+    if not seqs:
+        raise ValueError("Cannot pad empty sequence")
+    if len(set(seq.ndim for seq in seqs)) != 1:
+        raise ValueError("Cannot pad sequences with different ndims")
+    if len(set(seq.dtype for seq in seqs)) != 1:
+        raise ValueError("Cannot pad sequences with different dtypes")
+    if any(len(seq.shape) != 2 or seq.shape[0] != seq.shape[1] for seq in seqs):
+        raise ValueError("Cannot pad non-square matrices")
+    # Find the maximum dimension along each axis. That's what we'll pad to.
+    length = max(seq.shape[0] for seq in seqs)
+    # Round the length to nearest bucket -- helps on GPU, to make similar
+    # array sizes.
+    length = (length + (round_to - 1)) // round_to * round_to
+    final_shape = (len(seqs), length, length)
+    output = ops.alloc3f(*final_shape)
+    for i, arr in enumerate(seqs):
+        # It's difficult to convince this that the dtypes will match.
+        output[i, : arr.shape[0], : arr.shape[1]] = arr  # type: ignore[assignment, call-overload]
+    return output
+
+
+def unpad_matrix(padded: Floats3d, lengths: List[int]) -> List[Floats2d]:
+    """The reverse/backward operation of the `pad` function: transform an
+    array back into a list of arrays, each with their original length.
+
+    Different from Thinc, because it operates on a matrix with padding
+    in two dimensions.
+    """
+    output = []
+    for i, length in enumerate(lengths):
+        output.append(padded[i, :length, :length])
+    return cast(List[Floats2d], output)

--- a/spacy_experimental/biaffine_parser/with_splits.py
+++ b/spacy_experimental/biaffine_parser/with_splits.py
@@ -1,0 +1,82 @@
+from typing import Callable, List, Optional, Tuple
+from thinc.api import Model, Ops
+from thinc.types import Floats2d, Ints1d
+
+from ._util import lengths2offsets
+
+InT = Tuple[List[Floats2d], List[Ints1d]]
+OutT = List[Floats2d]
+InnerInT = List[Floats2d]
+InnerOutT = List[Floats2d]
+
+
+def with_splits(inner: Model[InnerInT, InnerOutT]) -> Model[InT, OutT]:
+    """This layer splits document representations (List[Floats2d], shape:
+    [doc_len, hidden_size]) into split representations (List[Floats2d], shape:
+    [n_splits, hidden_size]) and feeds them to the inner model.
+
+    A quirk is that the layer outputs per split rather than per doc. The reason
+    is that the arc predicter will output splits with the shape [split_len,
+    split_len]. Since the splits within a doc have different lengths, we cannot
+    concatenate then into a single doc representation (unless we add padding).
+    This is not an issue, since the arc predictes knows how to deal with
+    these output.
+    """
+    return Model(
+        "splits",
+        with_splits_forward,
+        init=with_splits_init,
+        layers=[inner],
+    )
+
+
+def with_splits_init(model: Model[InT, OutT], X: Optional[InT] = None, Y=None) -> None:
+    if X is None:
+        model.layers[0].initialize(X=X, Y=Y)
+    else:
+        X_flat, lengths = X
+        X_unflat = _unflatten_inner_flatten_outer(X_flat, lengths)
+        model.layers[0].initialize(X=X_unflat, Y=Y)
+
+
+def with_splits_forward(
+    model: Model[InT, OutT],
+    X_lengths: InT,
+    is_train: bool,
+) -> Tuple[OutT, Callable[[OutT], InT]]:
+    inner: Model[InnerInT, InnerOutT] = model.layers[0]
+
+    X, lengths = X_lengths
+
+    X_flat = _unflatten_inner_flatten_outer(X, lengths)
+    Y_unflat, backprop_inner = inner(X_flat, is_train)
+
+    def backprop(dY: OutT) -> InT:
+        dX_unflat = backprop_inner(dY)
+        return _unflatten_outer_flatten_inner(model.ops, dX_unflat, lengths), lengths
+
+    return Y_unflat, backprop
+
+
+def _unflatten_inner_flatten_outer(
+    X: List[Floats2d], lengths: List[Ints1d]
+) -> List[Floats2d]:
+    X_flat: List[Floats2d] = []
+    for X_inner, lengths_inner in zip(X, lengths):
+        split_offsets = lengths2offsets(lengths_inner)
+        X_flat.extend(
+            X_inner[split_offset : split_offset + split_length]
+            for split_offset, split_length in zip(split_offsets, lengths_inner)
+        )
+    return X_flat
+
+
+def _unflatten_outer_flatten_inner(
+    ops: Ops, X: List[Floats2d], lengths: List[Ints1d]
+) -> List[Floats2d]:
+    r = []
+    for lengths_inner in lengths:
+        inner = X[: len(lengths_inner)]
+        X = X[len(lengths_inner) :]
+        r.append(ops.flatten(inner))
+    return r


### PR DESCRIPTION
The Thinc part of the pairwire bilinear model is fairly simple before this change: we would collect the splits from all documents and then pad them. However, this caused the model to run out of memory on large docs, since it has to compute many n*n matrices (all padded to the longest sequence length). It would also perform unnecessary computations on many padding time steps.

This change make the memory use independent of the doc length (given a fixed split length) by doing the following:

- Get all splits and flatten to a list of split representations. (`with_splits`)
- Batch the splits by their padded sizes. This ensures that memory use is constant when splits have a maximum size. This also permits some buffering, so that we get more equisized batches. (`with_minibatch_by_padded_size`)
- The splits in the batches are padded and passed to the Torch model. Since the outputs of the Torch model are matrices, we unpad taking this into account. (`with_pad_seq_unpad_matrix`)

In contrast to most `with_*` layers, `with_splits` is not symmetric. It takes at its input representations for each document (`List[Floats2d]`), however it outputs pairwise score matrices per split. The reason is that since the dimensions of the score matrices differ per split, we cannot concatenate them at a document level.