### PR TITLE
Replace `torch.nn.Bilinear` by our own implementation

### DIFF
--- a/spacy_experimental/biaffine_parser/pytorch_bilinear.py
+++ b/spacy_experimental/biaffine_parser/pytorch_bilinear.py
@@ -2,6 +2,46 @@ import torch
 from torch import nn
 
 
+class Bilinear(nn.Module):
+    def __init__(
+        self, in_features: int, out_features: int, *, bias_u=True, bias_v=True
+    ):
+        super(Bilinear, self).__init__()
+
+        self.bias_u = bias_u
+        self.bias_v = bias_v
+
+        bias_u_dim = 1 if bias_u else 0
+        bias_v_dim = 1 if bias_v else 0
+
+        self.weight = nn.parameter.Parameter(
+            torch.empty(
+                out_features, in_features + bias_u_dim, in_features + bias_v_dim
+            )
+        )
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        nn.init.xavier_uniform_(self.weight)
+
+    def forward(self, u: torch.Tensor, v: torch.Tensor):
+        assert u.shape == v.shape, "Inputs to Bilinear must have the same shape"
+        assert len(u.shape) == 2, "Inputs to Bilinear must have a 2d shape"
+
+        batch_size, _ = u.shape
+
+        ones = torch.ones((batch_size, 1), dtype=u.dtype, device=u.device)
+
+        if self.bias_u:
+            u = torch.cat([u, ones], -1)
+
+        if self.bias_v:
+            v = torch.cat([v, ones], -1)
+
+        return torch.einsum("bu,bv,ouv->bo", u, v, self.weight)
+
+
 class BilinearModel(nn.Module):
     def __init__(
         self,
@@ -16,7 +56,7 @@ class BilinearModel(nn.Module):
 
         self.head = nn.Linear(nI, hidden_width)
         self.dependent = nn.Linear(nI, hidden_width)
-        self.bilinear = nn.Bilinear(hidden_width, hidden_width, nO)
+        self.bilinear = Bilinear(hidden_width, nO)
         self.activation = activation
         self._dropout = nn.Dropout(dropout)
 

--- a/spacy_experimental/biaffine_parser/pytorch_bilinear.py
+++ b/spacy_experimental/biaffine_parser/pytorch_bilinear.py
@@ -4,7 +4,12 @@ from torch import nn
 
 class Bilinear(nn.Module):
     def __init__(
-        self, in_features: int, out_features: int, *, bias_u=True, bias_v=True
+        self,
+        in_features: int,
+        out_features: int,
+        *,
+        bias_u: bool = True,
+        bias_v: bool = True,
     ):
         super(Bilinear, self).__init__()
 

--- a/spacy_experimental/biaffine_parser/pytorch_bilinear.py
+++ b/spacy_experimental/biaffine_parser/pytorch_bilinear.py
@@ -7,7 +7,7 @@ class Bilinear(nn.Module):
 
     This module provides functionality similar torch.nn.Bilinear.
     Differences are that this version uses a separate bias for
-    both inputs and it more efficient. See:
+    both inputs and is more efficient. See:
     https://github.com/explosion/spacy-experimental/pull/47"""
 
     def __init__(

--- a/spacy_experimental/biaffine_parser/pytorch_bilinear.py
+++ b/spacy_experimental/biaffine_parser/pytorch_bilinear.py
@@ -3,6 +3,11 @@ from torch import nn
 
 
 class Bilinear(nn.Module):
+    """Apply a bilinear transformation to the data: uAv + b
+
+    This module provides the same functionality as torch.nn.Bilinear,
+    but is more efficient. See:
+    https://github.com/explosion/spacy-experimental/pull/47"""
     def __init__(
         self,
         in_features: int,

--- a/spacy_experimental/biaffine_parser/pytorch_bilinear.py
+++ b/spacy_experimental/biaffine_parser/pytorch_bilinear.py
@@ -3,11 +3,13 @@ from torch import nn
 
 
 class Bilinear(nn.Module):
-    """Apply a bilinear transformation to the data: uAv + b
+    """Apply a bilinear transformation to the data: uAv
 
-    This module provides the same functionality as torch.nn.Bilinear,
-    but is more efficient. See:
+    This module provides functionality similar torch.nn.Bilinear.
+    Differences are that this version uses a separate bias for
+    both inputs and it more efficient. See:
     https://github.com/explosion/spacy-experimental/pull/47"""
+
     def __init__(
         self,
         in_features: int,

--- a/spacy_experimental/biaffine_parser/tests/test_pytorch_bilinear.py
+++ b/spacy_experimental/biaffine_parser/tests/test_pytorch_bilinear.py
@@ -1,0 +1,18 @@
+import torch
+from torch.nn import Bilinear as TorchBilinear
+
+from spacy_experimental.biaffine_parser.pytorch_bilinear import Bilinear
+
+
+def test_bilinear_against_torch():
+    # Disable biases, they are handled differently between our
+    # implementation and Torch.
+    torch_bilinear = TorchBilinear(5, 5, 7, bias=False)
+    bilinear = Bilinear(5, 7, bias_u=False, bias_v=False)
+    with torch.no_grad():
+        bilinear.weight.copy_(torch_bilinear.weight)
+
+    u = torch.rand((10, 5), dtype=torch.float32)
+    v = torch.rand((10, 5), dtype=torch.float32)
+
+    torch.testing.assert_close(bilinear(u, v), torch_bilinear(u, v))

--- a/spacy_experimental/biaffine_parser/tests/test_pytorch_bilinear.py
+++ b/spacy_experimental/biaffine_parser/tests/test_pytorch_bilinear.py
@@ -1,6 +1,10 @@
-import torch
-from torch.nn import Bilinear as TorchBilinear
+import pytest
 
+pytest.importorskip("torch")
+
+import torch
+
+from torch.nn import Bilinear as TorchBilinear
 from spacy_experimental.biaffine_parser.pytorch_bilinear import Bilinear
 
 


### PR DESCRIPTION
Torch's `Bilinear` layer uses the native torch `bilinear` function, which is quite a bit less efficient than using `einsum`. `bilinear` seems to run a separate matrix multiplication and bias addition per output. This change introduces our own `Bilinear` layer that uses `einsum`.

Before (arc labeling takes substantially more time than arc prediction):

<img width="1218" alt="before-refactor-nvtx" src="https://user-images.githubusercontent.com/49398/231258133-08ee924a-e5b6-4b6d-9342-00d922a6d922.png">

After (arc labeling takes less time than arc prediction):

<img width="865" alt="after-refactor" src="https://user-images.githubusercontent.com/49398/231258355-0778455f-5077-4a15-b8b2-889d81b4c7b8.png">
