### PR TITLE
Increment spaCy upper-bound to `<3.8.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools",
     "wheel",
     "Cython<3.0",
-    "spacy>=3.3.0,<3.7.0",
+    "spacy>=3.3.0,<3.8.0",
     "numpy>=1.15.0; python_version < '3.9'",
     "numpy>=1.25.0; python_version >= '3.9'",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-spacy>=3.3.0,<3.7.0
+spacy>=3.3.0,<3.8.0
 numpy>=1.15.0; python_version < "3.9"
 numpy>=1.19.0; python_version >= "3.9"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ long_description_content_type = text/markdown
 zip_safe = false
 python_requires = >=3.6
 install_requires =
-    spacy>=3.3.0,<3.7.0
+    spacy>=3.3.0,<3.8.0
     numpy>=1.15.0; python_version < "3.9"
     numpy>=1.19.0; python_version >= "3.9"
 


### PR DESCRIPTION
Adds support for spaCy 3.7.x.